### PR TITLE
Fix assimp Mesh Import

### DIFF
--- a/include/QEMOpenMesh.h
+++ b/include/QEMOpenMesh.h
@@ -3,6 +3,7 @@
 #include "QEMDebug.h"
 #include "assimp_helper.h"
 #include <vector>
+#include <map>
 
 #include <OpenMesh/Core/IO/MeshIO.hh>
 #include <OpenMesh/Core/Mesh/TriMesh_ArrayKernelT.hh>
@@ -39,12 +40,20 @@ class QEM
 	inline void ImportMesh(const Mesh &mesh)
 	{
 		std::vector<QEMMesh::VertexHandle> vhs;
+		std::map<std::array<double, 3>, QEMMesh::VertexHandle> mp;
 
 		for (int i = 0; i < mesh.V.rows(); i++)
 		{
-			auto vh = heMesh.add_vertex(OpenMesh::Vec3d(mesh.V(i, 0), mesh.V(i, 1), mesh.V(i, 2)));
-			heMesh.set_normal(vh, OpenMesh::Vec3d(mesh.N(i, 0), mesh.N(i, 1), mesh.N(i, 2)));
-			heMesh.set_texcoord2D(vh, OpenMesh::Vec2d(mesh.UV(i, 0), mesh.UV(i, 1)));
+			std::array<double, 3> pt{mesh.V(i, 0), mesh.V(i, 1), mesh.V(i, 2)};
+			QEMMesh::VertexHandle vh;
+			if (mp.find(pt) != mp.end())
+				vh = mp[pt];
+			else {
+				vh = heMesh.add_vertex(QEMMesh::Point(mesh.V(i, 0), mesh.V(i, 1), mesh.V(i, 2)));
+				heMesh.set_normal(vh, QEMMesh::Normal(mesh.N(i, 0), mesh.N(i, 1), mesh.N(i, 2)));
+				heMesh.set_texcoord2D(vh, QEMMesh::TexCoord2D(mesh.UV(i, 0), mesh.UV(i, 1)));
+				mp[pt] = vh;
+			}
 			vhs.push_back(vh);
 		}
 

--- a/include/QEMUHEMesh.h
+++ b/include/QEMUHEMesh.h
@@ -3,6 +3,7 @@
 #include "QEMDebug.h"
 #include <Eigen/Sparse>
 #include "assimp_helper.h"
+#include <map>
 
 class QEM
 {
@@ -122,9 +123,14 @@ public:
 	{
 		heMesh.Clear();
 
+		std::map<std::array<double, 3>, HEMesh::V*> mp;
+		std::vector<HEMesh::V*> verts;
+
 		for (size_t i = 0; i < mesh.V.rows(); i++)
 		{
-			heMesh.AddVertex(mesh.V.row(i), mesh.N.row(i), mesh.UV.row(i));
+			std::array<double, 3> pt{mesh.V(i, 0), mesh.V(i, 1), mesh.V(i, 2)};
+			if (mp.find(pt) == mp.end()) mp[pt] = heMesh.AddVertex(mesh.V.row(i), mesh.N.row(i), mesh.UV.row(i));
+			verts.push_back(mp[pt]);
 		}
 
 		for (size_t fIndex = 0; fIndex < mesh.F.rows(); fIndex++)
@@ -134,8 +140,8 @@ public:
 			{
 				size_t next = (i + 1) % 3;
 				assert(mesh.F(fIndex, i) != mesh.F(fIndex, next));
-				auto *u  = heMesh.Vertices()[mesh.F(fIndex, i)];
-				auto *v  = heMesh.Vertices()[mesh.F(fIndex, next)];
+				auto *u  = verts[mesh.F(fIndex, i)];
+				auto *v  = verts[mesh.F(fIndex, next)];
 				auto *he = u->HalfEdgeTo(v);
 				if (!he)
 				{


### PR DESCRIPTION
A mesh created by assimp may have multiple vertices sharing the same position.
This [link](https://stackoverflow.com/questions/40961441/mesh-simplification-with-assimp-and-openmesh) may be useful.